### PR TITLE
Update getting-started.md

### DIFF
--- a/_pages/getting-started.md
+++ b/_pages/getting-started.md
@@ -97,7 +97,7 @@ var projector = new Projector(mapBuilder)
 {
 	ShouldRetry = async (exception, attempts) =>
 	{
-		await Task.Delay(attempts ^ 2);
+		await Task.Delay(Math.Pow(2, attempts));
 
 		return (attempts < 3);
 	}


### PR DESCRIPTION
Similar to https://github.com/dennisdoomen/dennisdoomen.github.io/pull/38/commits/67fdd3d218849d15dded3413b284184bc28ecff0

Code snippet fix, instead of delaying by 'attempts XOR 2' seconds, taking '2 to the power of attempts' seconds, so it's complying with the statement "(...) This makes it very trivial to implement an exponential back-off strategy (...)".